### PR TITLE
記事ページのための前準備を施した

### DIFF
--- a/components/02_molecules/CardItem.vue
+++ b/components/02_molecules/CardItem.vue
@@ -1,9 +1,11 @@
 <template>
-  <v-card width="300" height="225" max-width="300" max-height="225">
-    <card-img :src="src" />
-    <card-title :title="title" />
-    <card-text :text="text" />
-  </v-card>
+  <nuxt-link :to="url" style="text-decoration: none">
+    <v-card width="300" height="225" max-width="300" max-height="225">
+      <card-img :src="src" />
+      <card-title :title="title" />
+      <card-text :text="text" />
+    </v-card>
+  </nuxt-link>
 </template>
 
 <script>
@@ -14,6 +16,10 @@ export default {
   name: 'CardItem',
   components: { CardText, CardTitle, CardImg },
   props: {
+    slug: {
+      type: String,
+      default: ''
+    },
     src: {
       type: String,
       default: ''
@@ -25,6 +31,11 @@ export default {
     text: {
       type: String,
       default: ''
+    }
+  },
+  computed: {
+    url() {
+      return `/posts/${this.slug}`
     }
   }
 }

--- a/components/02_molecules/CardItem.vue
+++ b/components/02_molecules/CardItem.vue
@@ -1,10 +1,18 @@
 <template>
   <nuxt-link :to="url" style="text-decoration: none">
-    <v-card width="300" height="225" max-width="300" max-height="225">
-      <card-img :src="src" />
-      <card-title :title="title" />
-      <card-text :text="text" />
-    </v-card>
+    <v-hover v-slot:default="{ hover }">
+      <v-card
+        :elevation="hover ? 7 : 2"
+        width="300"
+        height="225"
+        max-width="300"
+        max-height="225"
+      >
+        <card-img :src="src" />
+        <card-title :title="title" />
+        <card-text :text="text" />
+      </v-card>
+    </v-hover>
   </nuxt-link>
 </template>
 

--- a/components/03_organisms/CardItemList.vue
+++ b/components/03_organisms/CardItemList.vue
@@ -2,7 +2,12 @@
   <v-container>
     <v-row justify="center" align-content="start">
       <v-col v-for="(card, index) in cards" :key="index" cols="auto">
-        <card-item :src="card.src" :title="card.title" :text="card.text" />
+        <card-item
+          :slug="card.slug"
+          :src="card.src"
+          :title="card.title"
+          :text="card.text"
+        />
       </v-col>
     </v-row>
   </v-container>

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,4 +1,8 @@
+import { createClient } from 'contentful'
+import { config } from 'dotenv'
 import website from './config/website'
+
+config()
 
 export default {
   mode: 'spa',
@@ -40,5 +44,19 @@ export default {
   },
   build: {
     extend(config, ctx) {}
+  },
+  generate: {
+    async routes() {
+      const config = {
+        space: process.env.CTF_SPACE_ID,
+        accessToken: process.env.CTF_ACCESS_TOKEN
+      }
+      const contentType = process.env.CTF_CONTENT_TYPE_ID
+      const client = createClient(config)
+      const routing = await client.getEntries(contentType).then((entries) => {
+        return [...entries.items.map((entry) => `/posts/${entry.fields.slug}`)]
+      })
+      return routing
+    }
   }
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,5 +1,16 @@
 <template>
-  <v-container>
-    <p>Init</p>
-  </v-container>
+  <div>
+    <card-item-list :cards="entries" />
+  </div>
 </template>
+<script>
+import CardItemList from '../components/03_organisms/CardItemList'
+import { findAllEntries } from '../plugins/contentful'
+export default {
+  components: { CardItemList },
+  async asyncData() {
+    const entries = await findAllEntries()
+    return { entries }
+  }
+}
+</script>

--- a/pages/posts/_id.vue
+++ b/pages/posts/_id.vue
@@ -1,0 +1,24 @@
+<template>
+  <v-container>
+    <v-layout>
+      <div v-html="contents" class="markdown" />
+    </v-layout>
+  </v-container>
+</template>
+
+<script>
+import { findEntryById } from '../../plugins/contentful'
+
+export default {
+  computed: {
+    contents() {
+      const body = this.entry.body
+      return this.$md.render(body)
+    }
+  },
+  async asyncData({ params }) {
+    const entry = await findEntryById(params.id)
+    return { entry }
+  }
+}
+</script>

--- a/pages/posts/index.vue
+++ b/pages/posts/index.vue
@@ -1,0 +1,11 @@
+<template>
+  <div />
+</template>
+
+<script>
+export default {
+  fetch({ redirect }) {
+    redirect(301, '/posts/1')
+  }
+}
+</script>

--- a/plugins/contentful.js
+++ b/plugins/contentful.js
@@ -5,7 +5,7 @@ const config = {
   accessToken: process.env.CTF_ACCESS_TOKEN
 }
 
-const contentType = process.env.CTF_CONTENT_TYPE
+const contentType = process.env.CTF_CONTENT_TYPE_ID
 const client = createClient(config)
 
 // Contentfulより全記事取得
@@ -30,14 +30,19 @@ export const findAllEntries = () => {
 
 // IDを指定して特定の記事を取得
 export const findEntryById = (id) => {
-  return client.getEntries(id).then((entries) => {
-    const entry = entries.items[0]
-    return {
-      title: entry.fields.title,
-      text: entry.fields.text,
-      slug: entry.fields.slug,
-      src: `https:${entry.fields.image.fields.file.url}`,
-      body: entry.fields.body
-    }
-  })
+  return client
+    .getEntries({
+      content_type: contentType,
+      'fields.slug': id
+    })
+    .then((entries) => {
+      const entry = entries.items[0]
+      return {
+        title: entry.fields.title,
+        text: entry.fields.text,
+        slug: entry.fields.slug,
+        src: `https:${entry.fields.image.fields.file.url}`,
+        body: entry.fields.body
+      }
+    })
 }


### PR DESCRIPTION
## 概要
記事ページのための前準備にあたって下記を実装した。

- IDを指定して記事取得の挙動修正
- 記事カードの表示
- 記事取得およびページ遷移
- nuxt generate時に静的ページを生成
