### PR TITLE
タグ検索機能の追加

### DIFF
--- a/components/03_organisms/TagItemList.vue
+++ b/components/03_organisms/TagItemList.vue
@@ -2,7 +2,9 @@
   <v-container>
     <v-row justify="center" align-content="center" style="height: 50px">
       <v-col v-for="(tag, index) in tags" :key="index" cols="auto">
-        <tag-item :tag="tag" />
+        <div @click="click(tag)">
+          <tag-item :tag="tag" />
+        </div>
       </v-col>
     </v-row>
   </v-container>
@@ -16,6 +18,12 @@ export default {
   data() {
     return {
       tags: ['ALL', 'WEB', 'DESIGN']
+    }
+  },
+  methods: {
+    click(tag) {
+      const keyword = tag === 'ALL' ? '' : tag
+      this.$emit('keyword', keyword)
     }
   }
 }

--- a/components/03_organisms/TagItemList.vue
+++ b/components/03_organisms/TagItemList.vue
@@ -22,8 +22,7 @@ export default {
   },
   methods: {
     click(tag) {
-      const keyword = tag === 'ALL' ? '' : tag
-      this.$emit('keyword', keyword)
+      this.$emit('keyword', tag)
     }
   }
 }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <search-box @keyword="setKeyword" />
-    <tag-item-list />
+    <tag-item-list @keyword="setKeyword" />
     <card-item-list :cards="filteredEntries" />
   </div>
 </template>

--- a/plugins/contentful.js
+++ b/plugins/contentful.js
@@ -22,7 +22,8 @@ export const findAllEntries = () => {
           text: value.fields.text,
           slug: value.fields.slug,
           src: `https:${value.fields.image.fields.file.url}`,
-          body: value.fields.body
+          body: value.fields.body,
+          tags: value.fields.tags
         }
       })
     })
@@ -42,7 +43,8 @@ export const findEntryById = (id) => {
         text: entry.fields.text,
         slug: entry.fields.slug,
         src: `https:${entry.fields.image.fields.file.url}`,
-        body: entry.fields.body
+        body: entry.fields.body,
+        tags: entry.fields.tags
       }
     })
 }

--- a/plugins/fuse.js
+++ b/plugins/fuse.js
@@ -1,7 +1,7 @@
 import Fuse from 'fuse.js'
 
 export const getFilteredEntries = (keyword, entries) => {
-  if (keyword.length === 0) {
+  if (keyword.length === 0 || keyword === 'ALL') {
     return entries
   }
 

--- a/plugins/fuse.js
+++ b/plugins/fuse.js
@@ -7,7 +7,7 @@ export const getFilteredEntries = (keyword, entries) => {
 
   const options = {
     threshold: 0.3,
-    keys: ['title']
+    keys: ['title', 'tags']
   }
   return new Fuse(entries, options).search(keyword)
 }


### PR DESCRIPTION
## 概要
タグボタンをクリックした際に、pages/index.vueのkeywordにemitを用いて伝達する仕組みを実装した。
検索ボックスで使用している関数を再利用している。