### PR TITLE
記事ページのパスが誤っている箇所を修正

### DIFF
--- a/pages/posts/_id.vue
+++ b/pages/posts/_id.vue
@@ -48,7 +48,7 @@ export default {
         {
           hid: 'og:url',
           property: 'og:url',
-          content: `${process.env.website.url}/${this.$route.path}`
+          content: `${process.env.website.url}${this.$route.path}`
         },
         {
           hid: 'og:title',
@@ -69,7 +69,7 @@ export default {
         {
           hid: 'twitter:site',
           name: 'twitter:site',
-          content: `${process.env.website.url}/${this.$route.path}`
+          content: `${process.env.website.url}${this.$route.path}`
         },
         {
           hid: 'twitter:card',


### PR DESCRIPTION
## 概要
"https://zu-tech.netlify.com//posts/20200120" のようになっており、スラッシュが1つ多かったのを修正。