### PR TITLE
記事ページのトップ画像がオートスケールするように変更

### DIFF
--- a/components/01_atoms/PostImg.vue
+++ b/components/01_atoms/PostImg.vue
@@ -1,5 +1,11 @@
 <template>
-  <v-img :alt="title" :src="src" width="640px" height="275px" />
+  <v-img
+    :alt="title"
+    :src="src"
+    :contain="true"
+    height="275px"
+    max-width="640px"
+  />
 </template>
 
 <script>


### PR DESCRIPTION
## 概要
モバイルで表示した時に画像が見切れてしまっていた。
そこで、v-imgにcontainを付与することでオートスケールするように変更した。