### PR TITLE
aタグの色を技術ブログに合わせて調整

### DIFF
--- a/assets/variables.scss
+++ b/assets/variables.scss
@@ -5,7 +5,7 @@ $body-font-family: Helvetica Neue, Helvetica, Hiragino Sans,
 @import '~vuetify/src/styles/styles.sass';
 
 // colors
-$primary: #b8d8ba;
+$primary: #89b0ae;
 $secondary: #d9dbbc;
 $warning: #fcddbc;
 $danger: #ef959d;

--- a/components/03_organisms/PostContent.vue
+++ b/components/03_organisms/PostContent.vue
@@ -59,6 +59,7 @@ export default {
 
   a {
     text-decoration: none;
+    color: $primary !important;
   }
 
   ul,


### PR DESCRIPTION
## 概要
aタグのデフォルトカラーから変更した。