### PR TITLE
記事ページでフッターと記事が重なってしまう問題を修正

### DIFF
--- a/pages/posts/_id.vue
+++ b/pages/posts/_id.vue
@@ -13,7 +13,7 @@
 
     <share-item-list :title="entry.title" />
 
-    <post-content :body="entry.body" />
+    <post-content :body="entry.body" class="post-content" />
   </v-container>
 </template>
 
@@ -87,5 +87,9 @@ export default {
 <style scoped lang="scss">
 .post-page {
   max-width: 800px;
+}
+
+.post-content {
+  margin-bottom: 50px;
 }
 </style>


### PR DESCRIPTION
## 概要
記事ページでフッターと記事が重なってしまう問題があったが、マージンを適用することにより修正した。